### PR TITLE
Fix typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if PY_33:
 # if not PY_35:
 #     install_requires.append('typing')
 
-tests_require = install_requires + ['py.test']
+tests_require = install_requires + ['pytest']
 extras_require = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if PY_33:
 # if not PY_35:
 #     install_requires.append('typing')
 
-tests_require = install_requires + ['py.tests']
+tests_require = install_requires + ['py.test']
 extras_require = {}
 
 


### PR DESCRIPTION
* Change package name to `pytest` so now `python setup.py test` is working properly.
Sorry for such a great contribution