### PR TITLE
expose the unfinished tasks variable

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -219,6 +219,10 @@ class _SyncQueueProxy:
         '''Return the approximate size of the queue (not reliable!).'''
         return self._parent._qsize()
 
+    def unfinished(self):
+        '''Return the number of unfinished tasks.'''
+        return self._parent._unfinished_tasks
+
     def empty(self):
         '''Return True if the queue is empty, False otherwise (not reliable!).
 
@@ -340,6 +344,10 @@ class _AsyncQueueProxy:
     def qsize(self):
         """Number of items in the queue."""
         return self._parent._qsize()
+
+    def unfinished(self):
+        '''Return the number of unfinished tasks.'''
+        return self._parent._unfinished_tasks
 
     @property
     def maxsize(self):

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -219,7 +219,8 @@ class _SyncQueueProxy:
         '''Return the approximate size of the queue (not reliable!).'''
         return self._parent._qsize()
 
-    def unfinished(self):
+    @property
+    def unfinished_tasks(self):
         '''Return the number of unfinished tasks.'''
         return self._parent._unfinished_tasks
 
@@ -345,7 +346,8 @@ class _AsyncQueueProxy:
         """Number of items in the queue."""
         return self._parent._qsize()
 
-    def unfinished(self):
+    @property
+    def unfinished_tasks(self):
         '''Return the number of unfinished tasks.'''
         return self._parent._unfinished_tasks
 

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -56,7 +56,7 @@ class TestMixedMode(unittest.TestCase):
         q.sync_q.task_done()
         self.assertEqual(q.sync_q.unfinished_tasks, 0)
         self.assertEqual(q.async_q.unfinished_tasks, 0)
-        
+
     def test_sync_put_async_get(self):
         q = janus.Queue(loop=self.loop)
 

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -43,6 +43,20 @@ class TestMixedMode(unittest.TestCase):
         q = janus.Queue(loop=self.loop)
         self.assertIs(0, q.maxsize)
 
+    def test_unfinished(self):
+        q = janus.Queue(loop=self.loop)
+        self.assertEqual(q.sync_q.unfinished_tasks, 0)
+        self.assertEqual(q.async_q.unfinished_tasks, 0)
+        q.sync_q.put(1)
+        self.assertEqual(q.sync_q.unfinished_tasks, 1)
+        self.assertEqual(q.async_q.unfinished_tasks, 1)
+        q.sync_q.get()
+        self.assertEqual(q.sync_q.unfinished_tasks, 1)
+        self.assertEqual(q.async_q.unfinished_tasks, 1)
+        q.sync_q.task_done()
+        self.assertEqual(q.sync_q.unfinished_tasks, 0)
+        self.assertEqual(q.async_q.unfinished_tasks, 0)
+        
     def test_sync_put_async_get(self):
         q = janus.Queue(loop=self.loop)
 


### PR DESCRIPTION
I use `queue.empty() and queue._parent._unfinished_tasks == 0` to check whether a queue is complete and this pull request exposes the _unfinished_tasks variable. 

My use case is 2 queues that can send work to each other until both are complete - is there a better way to achieve this? Note that I'm not trying to `join()` since a thread should wake up if there is more work to do.
