### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Topic :: Software Development :: Libraries'
+        'Topic :: Software Development :: Libraries',
+        'Framework :: AsyncIO',
     ],
     author='Andrew Svetlov',
     author_email='andrew.svetlov@gmail.com',


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.