### PR TITLE
async_q.join() sometimes never return

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -277,8 +277,7 @@ class _SyncQueueProxy:
                         if remaining <= 0.0:
                             raise SyncQueueFull
                         self._parent._sync_not_full.wait(remaining)
-            self._parent._put(item)
-            self._parent._unfinished_tasks += 1
+            self._parent._put_internal(item)
             self._parent._sync_not_empty.notify()
             self._parent._notify_async_not_empty(threadsafe=True)
 

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -95,8 +95,7 @@ class TestMixedMode(unittest.TestCase):
 
         @asyncio.coroutine
         def wait_for_empty_queue():
-            while not q.async_q.empty():
-                yield from q.async_q.join()
+            yield from q.async_q.join()
             task.cancel()
 
         self.loop.run_until_complete(wait_for_empty_queue())

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -86,7 +86,7 @@ class TestMixedMode(unittest.TestCase):
 
         @asyncio.coroutine
         def do_work():
-            yield from asyncio.sleep(1)
+            yield from asyncio.sleep(1, loop=self.loop)
             while True:
                 yield from q.async_q.get()
                 q.async_q.task_done()


### PR DESCRIPTION
async_q.join() will never return in case when tasks are added to queue via sync_q.put()