### PR TITLE
Fix Syntax error with Python 3.7

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__package__)
 try:
     ensure_future = asyncio.ensure_future
 except AttributeError:
-    ensure_future = asyncio.async
+    ensure_future = getattr(asyncio, 'async')
 
 
 class Queue:


### PR DESCRIPTION
`async` is reserved keyword in Python 3.7

Fix issue #95
Most likely https://github.com/Rapptz/discord.py/commit/096584733e8a8025b13f46fa920e18abe19352c1