### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,6 @@ bandit==1.6.2
 coverage==5.0
 docutils==0.15.2
 flake8==3.7.9
-ipdb==0.12.3
-ipython==7.9.0
 mypy==0.750
 pyroma==2.6
 pytest-cov==2.8.1


### PR DESCRIPTION
`ipython` and `ipdb` are not necessary (but handy) for development.

They run faster than `janus`, `ipython` had cut the list of supported Python versions.
There is no reason to keep these requirements, people always can install them manually.