### PR TITLE
Fix up Python 3.8 loop argument warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,8 @@ target/
 
 coverage
 
-.pytest_cache
+.pytest_cache/
+.mypy_cache/
+
+# pyenv
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+to be released
+--------------
+
+- Remove explicit loop arguments and forbid creating queues outside event loops #246
+
 0.4.0 (2018-07-28)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,16 +26,13 @@ Synchronous is fully compatible with `standard queue
 follows `asyncio queue design
 <https://docs.python.org/3/library/asyncio-queue.html>`_.
 
-Usage example
-=============
+Usage example (Python 3.7+)
+===========================
 
 .. code:: python
 
     import asyncio
     import janus
-
-    loop = asyncio.get_event_loop()
-    queue = janus.Queue(loop=loop)
 
 
     def threaded(sync_q):
@@ -51,9 +48,55 @@ Usage example
             async_q.task_done()
 
 
-    fut = loop.run_in_executor(None, threaded, queue.sync_q)
-    loop.run_until_complete(async_coro(queue.async_q))
-    loop.run_until_complete(fut)
+    async def main():
+        queue = janus.Queue()
+        loop = asyncio.get_running_loop()
+        fut = loop.run_in_executor(None, threaded, queue.sync_q)
+        await async_coro(queue.async_q)
+        await fut
+        queue.close()
+        await queue.wait_closed()
+
+
+    asyncio.run(main())
+
+
+Usage example (Python 3.5 and 3.6)
+==================================
+
+.. code:: python
+
+    import asyncio
+    import janus
+
+    loop = asyncio.get_event_loop()
+
+
+    def threaded(sync_q):
+        for i in range(100):
+            sync_q.put(i)
+        sync_q.join()
+
+
+    async def async_coro(async_q):
+        for i in range(100):
+            val = await async_q.get()
+            assert val == i
+            async_q.task_done()
+
+
+    async def main():
+        queue = janus.Queue()
+        fut = loop.run_in_executor(None, threaded, queue.sync_q)
+        await async_coro(queue.async_q)
+        await fut
+        queue.close()
+        await queue.wait_closed()
+
+    try:
+        loop.run_until_complete(main())
+    finally:
+        loop.close()
 
 
 Communication channels

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -19,9 +19,8 @@ T = TypeVar('T')
 OptInt = Optional[int]
 
 
-if hasattr(asyncio, 'get_running_loop'):
-    current_loop = asyncio.get_running_loop
-else:
+current_loop = getattr(asyncio, 'get_running_loop', None)
+if current_loop is None:
     current_loop = asyncio.get_event_loop
 
 

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -19,7 +19,7 @@ T = TypeVar('T')
 OptInt = Optional[int]
 
 
-if getattr(asyncio, 'get_running_loop'):
+if hasattr(asyncio, 'get_running_loop'):
     current_loop = asyncio.get_running_loop
 else:
     current_loop = asyncio.get_event_loop

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ mypy==0.770
 pyroma==2.6
 pytest-cov==2.8.1
 pytest==5.4.1
+pytest-asyncio==0.10.0
 tox==3.14.6
 wheel==0.34.2

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@ import sys
 
 from setuptools.command.test import test as TestCommand
 
-PY_33 = sys.version_info < (3, 4)
-PY_35 = sys.version_info >= (3, 5)
-
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
@@ -42,12 +39,6 @@ def read(f):
 
 
 install_requires = []
-
-if PY_33:
-    install_requires.append('asyncio')
-
-# if not PY_35:
-#     install_requires.append('typing')
 
 tests_require = install_requires + [
     'pytest>=5.4',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ if PY_33:
 # if not PY_35:
 #     install_requires.append('typing')
 
-tests_require = install_requires + ['pytest']
+tests_require = install_requires + [
+    'pytest>=5.4',
+    'pytest-asyncio>=0.10.0',
+]
 extras_require = {}
 
 
@@ -66,6 +69,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries',
         'Framework :: AsyncIO',
     ],

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,66 +1,56 @@
 """Tests for queues.py"""
 
 import asyncio
-import concurrent.futures
 import unittest
 
 import janus
+import pytest
 
 
-class _QueueTestBase(unittest.TestCase):
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
-        self.loop.set_default_executor(self.executor)
-        asyncio.set_event_loop(None)
+class QueueBasicTests(unittest.TestCase):
 
-    def tearDown(self):
-        self.executor.shutdown()
-        self.loop.close()
-
-
-class QueueBasicTests(_QueueTestBase):
-    def _test_repr_or_str(self, fn, expect_id):
+    async def _test_repr_or_str(self, fn, expect_id):
         """Test Queue's repr or str.
 
         fn is repr or str. expect_id is True if we expect the Queue's id to
         appear in fn(Queue()).
         """
 
-        _q = janus.Queue(loop=self.loop)
+        _q = janus.Queue()
         q = _q.async_q
         self.assertTrue(fn(q).startswith('<Queue'), fn(q))
         id_is_present = hex(id(q)) in fn(q)
         self.assertEqual(expect_id, id_is_present)
+        loop = janus.current_loop()
 
         async def add_getter():
-            _q = janus.Queue(loop=self.loop)
+            _q = janus.Queue()
             q = _q.async_q
             # Start a task that waits to get.
-            self.loop.create_task(q.get())
+            loop.create_task(q.get())
             # Let it start waiting.
             await asyncio.sleep(0.1)
             self.assertTrue('_getters[1]' in fn(q))
             # resume q.get coroutine to finish generator
             q.put_nowait(0)
 
-        self.loop.run_until_complete(add_getter())
+        await add_getter()
 
         async def add_putter():
-            _q = janus.Queue(maxsize=1, loop=self.loop)
+            _q = janus.Queue(maxsize=1)
             q = _q.async_q
             q.put_nowait(1)
             # Start a task that waits to put.
-            self.loop.create_task(q.put(2))
+            loop.create_task(q.put(2))
             # Let it start waiting.
             await asyncio.sleep(0.1)
             self.assertTrue('_putters[1]' in fn(q))
             # resume q.put coroutine to finish generator
             q.get_nowait()
 
-        self.loop.run_until_complete(add_putter())
+        await add_putter()
 
-        _q = janus.Queue(loop=self.loop)
+        _q = janus.Queue()
         q = _q.async_q
         q.put_nowait(1)
         self.assertTrue('_queue=[1]' in fn(q))
@@ -71,8 +61,9 @@ class QueueBasicTests(_QueueTestBase):
     # def test_str(self):
     #     self._test_repr_or_str(str, False)
 
-    def test_empty(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_empty(self):
+        _q = janus.Queue()
         q = _q.async_q
         self.assertTrue(q.empty())
         q.put_nowait(1)
@@ -82,24 +73,26 @@ class QueueBasicTests(_QueueTestBase):
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_full(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_full(self):
+        _q = janus.Queue()
         q = _q.async_q
         self.assertFalse(q.full())
 
-        _q = janus.Queue(maxsize=1, loop=self.loop)
+        _q = janus.Queue(maxsize=1)
         q = _q.async_q
         q.put_nowait(1)
         self.assertTrue(q.full())
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_order(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_order(self):
+        _q = janus.Queue()
         q = _q.async_q
         for i in [1, 3, 2]:
             q.put_nowait(i)
@@ -109,15 +102,17 @@ class QueueBasicTests(_QueueTestBase):
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_maxsize(self):
-        _q = janus.Queue(maxsize=2, loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_maxsize(self):
+        loop = janus.current_loop()
+        _q = janus.Queue(maxsize=2)
         q = _q.async_q
         self.assertEqual(2, q.maxsize)
         have_been_put = []
 
-        fut = self.loop.create_future()
+        fut = loop.create_future()
 
         async def putter():
             for i in range(3):
@@ -128,7 +123,7 @@ class QueueBasicTests(_QueueTestBase):
             return True
 
         async def test():
-            t = self.loop.create_task(putter())
+            t = loop.create_task(putter())
             await fut
 
             # The putter is blocked after putting two items.
@@ -141,58 +136,61 @@ class QueueBasicTests(_QueueTestBase):
             self.assertEqual(1, q.get_nowait())
             self.assertEqual(2, q.get_nowait())
 
-        self.loop.run_until_complete(test())
+        await test()
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
 
-class QueueGetTests(_QueueTestBase):
-    def test_blocking_get(self):
-        _q = janus.Queue(loop=self.loop)
+class QueueGetTests(unittest.TestCase):
+
+    @pytest.mark.asyncio
+    async def test_blocking_get(self):
+        _q = janus.Queue()
         q = _q.async_q
         q.put_nowait(1)
 
-        async def queue_get():
-            return (await q.get())
-
-        res = self.loop.run_until_complete(queue_get())
+        res = await q.get()
         self.assertEqual(1, res)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_get_with_putters(self):
-        _q = janus.Queue(1, loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_get_with_putters(self):
+        loop = janus.current_loop()
+        _q = janus.Queue(1)
         q = _q.async_q
         q.put_nowait(1)
 
-        fut = self.loop.create_future()
+        fut = loop.create_future()
 
         async def put():
-            t = asyncio.ensure_future(q.put(2), loop=self.loop)
+            t = asyncio.ensure_future(q.put(2))
             await asyncio.sleep(0.01)
             fut.set_result(None)
             return t
 
-        t = self.loop.run_until_complete(put())
+        t = await put()
 
-        res = self.loop.run_until_complete(q.get())
+        res = await q.get()
         self.assertEqual(1, res)
 
-        self.loop.run_until_complete(t)
+        await t
         self.assertEqual(1, q.qsize())
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_blocking_get_wait(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_blocking_get_wait(self):
+        loop = janus.current_loop()
+        _q = janus.Queue()
         q = _q.async_q
-        started = asyncio.Event(loop=self.loop)
+        started = asyncio.Event()
         finished = False
 
         async def queue_get():
@@ -203,122 +201,131 @@ class QueueGetTests(_QueueTestBase):
             return res
 
         async def queue_put():
-            self.loop.call_later(0.01, q.put_nowait, 1)
-            queue_get_task = self.loop.create_task(queue_get())
+            loop.call_later(0.01, q.put_nowait, 1)
+            queue_get_task = loop.create_task(queue_get())
             await started.wait()
             self.assertFalse(finished)
             res = await queue_get_task
             self.assertTrue(finished)
             return res
 
-        res = self.loop.run_until_complete(queue_put())
+        res = await queue_put()
         self.assertEqual(1, res)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_nonblocking_get(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_nonblocking_get(self):
+        _q = janus.Queue()
         q = _q.async_q
         q.put_nowait(1)
         self.assertEqual(1, q.get_nowait())
 
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_nonblocking_get_exception(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_nonblocking_get_exception(self):
+        _q = janus.Queue()
         self.assertRaises(asyncio.QueueEmpty, _q.async_q.get_nowait)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_get_cancelled(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_get_cancelled(self):
+        loop = janus.current_loop()
+        _q = janus.Queue()
         q = _q.async_q
 
         async def queue_get():
             return await asyncio.wait_for(q.get(), 0.051)
 
         async def test():
-            get_task = self.loop.create_task(queue_get())
+            get_task = loop.create_task(queue_get())
             await asyncio.sleep(0.01)  # let the task start
             q.put_nowait(1)
             return await get_task
 
-        self.assertEqual(1, self.loop.run_until_complete(test()))
+        self.assertEqual(1, await test())
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_get_cancelled_race(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_get_cancelled_race(self):
+        loop = janus.current_loop()
+        _q = janus.Queue()
         q = _q.async_q
 
-        f1 = self.loop.create_future()
+        f1 = loop.create_future()
 
         async def g1():
             f1.set_result(None)
             await q.get()
 
-        t1 = self.loop.create_task(g1())
-        t2 = self.loop.create_task(q.get())
+        t1 = loop.create_task(g1())
+        t2 = loop.create_task(q.get())
 
-        self.loop.run_until_complete(f1)
-        self.loop.run_until_complete(asyncio.sleep(0.01))
+        await f1
+        await asyncio.sleep(0.01)
         t1.cancel()
 
         with self.assertRaises(asyncio.CancelledError):
-            self.loop.run_until_complete(t1)
+            await t1
         self.assertTrue(t1.done())
         q.put_nowait('a')
 
-        self.loop.run_until_complete(t2)
+        await t2
         self.assertEqual(t2.result(), 'a')
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_get_with_waiting_putters(self):
-        _q = janus.Queue(loop=self.loop, maxsize=1)
+    @pytest.mark.asyncio
+    async def test_get_with_waiting_putters(self):
+        loop = janus.current_loop()
+        _q = janus.Queue(maxsize=1)
         q = _q.async_q
 
-        self.loop.create_task(q.put('a'))
-        self.loop.create_task(q.put('b'))
+        loop.create_task(q.put('a'))
+        loop.create_task(q.put('b'))
 
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        await asyncio.sleep(0.01)
 
-        self.assertEqual(self.loop.run_until_complete(q.get()), 'a')
-        self.assertEqual(self.loop.run_until_complete(q.get()), 'b')
+        self.assertEqual(await q.get(), 'a')
+        self.assertEqual(await q.get(), 'b')
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
 
-class QueuePutTests(_QueueTestBase):
-    def test_blocking_put(self):
-        _q = janus.Queue(loop=self.loop)
+class QueuePutTests(unittest.TestCase):
+
+    @pytest.mark.asyncio
+    async def test_blocking_put(self):
+        _q = janus.Queue()
         q = _q.async_q
 
-        async def queue_put():
-            # No maxsize, won't block.
-            await q.put(1)
-
-        self.loop.run_until_complete(queue_put())
+        # No maxsize, won't block.
+        await q.put(1)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_blocking_put_wait(self):
-        _q = janus.Queue(maxsize=1, loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_blocking_put_wait(self):
+        loop = janus.current_loop()
+        _q = janus.Queue(maxsize=1)
         q = _q.async_q
-        started = asyncio.Event(loop=self.loop)
+        started = asyncio.Event()
         finished = False
 
         async def queue_put():
@@ -329,41 +336,44 @@ class QueuePutTests(_QueueTestBase):
             finished = True
 
         async def queue_get():
-            self.loop.call_later(0.01, q.get_nowait)
-            queue_put_task = self.loop.create_task(queue_put())
+            loop.call_later(0.01, q.get_nowait)
+            queue_put_task = loop.create_task(queue_put())
             await started.wait()
             self.assertFalse(finished)
             await queue_put_task
             self.assertTrue(finished)
 
-        self.loop.run_until_complete(queue_get())
+        await queue_get()
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_nonblocking_put(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_nonblocking_put(self):
+        _q = janus.Queue()
         q = _q.async_q
         q.put_nowait(1)
         self.assertEqual(1, q.get_nowait())
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_nonblocking_put_exception(self):
-        _q = janus.Queue(maxsize=1, loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_nonblocking_put_exception(self):
+        _q = janus.Queue(maxsize=1)
         q = _q.async_q
         q.put_nowait(1)
         self.assertRaises(asyncio.QueueFull, q.put_nowait, 2)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_float_maxsize(self):
-        _q = janus.Queue(maxsize=1.3, loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_float_maxsize(self):
+        _q = janus.Queue(maxsize=1.3)
         q = _q.async_q
         q.put_nowait(1)
         q.put_nowait(2)
@@ -371,9 +381,9 @@ class QueuePutTests(_QueueTestBase):
         self.assertRaises(asyncio.QueueFull, q.put_nowait, 3)
 
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-        _q = janus.Queue(maxsize=1.3, loop=self.loop)
+        _q = janus.Queue(maxsize=1.3)
         q = _q.async_q
 
         async def queue_put():
@@ -381,14 +391,16 @@ class QueuePutTests(_QueueTestBase):
             await q.put(2)
             self.assertTrue(q.full())
 
-        self.loop.run_until_complete(queue_put())
+        await queue_put()
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_put_cancelled(self):
-        _q = janus.Queue(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_put_cancelled(self):
+        loop = janus.current_loop()
+        _q = janus.Queue()
         q = _q.async_q
 
         async def queue_put():
@@ -398,30 +410,32 @@ class QueuePutTests(_QueueTestBase):
         async def test():
             return (await q.get())
 
-        t = self.loop.create_task(queue_put())
-        self.assertEqual(1, self.loop.run_until_complete(test()))
+        t = loop.create_task(queue_put())
+        self.assertEqual(1, await test())
         self.assertTrue(t.done())
         self.assertTrue(t.result())
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_put_cancelled_race(self):
-        _q = janus.Queue(loop=self.loop, maxsize=1)
+    @pytest.mark.asyncio
+    async def test_put_cancelled_race(self):
+        loop = janus.current_loop()
+        _q = janus.Queue(maxsize=1)
         q = _q.async_q
 
-        put_a = self.loop.create_task(q.put('a'))
-        put_b = self.loop.create_task(q.put('b'))
-        put_c = self.loop.create_task(q.put('X'))
+        put_a = loop.create_task(q.put('a'))
+        put_b = loop.create_task(q.put('b'))
+        put_c = loop.create_task(q.put('X'))
 
-        self.loop.run_until_complete(put_a)
+        await put_a
         self.assertFalse(put_b.done())
 
         put_c.cancel()
 
         with self.assertRaises(asyncio.CancelledError):
-            self.loop.run_until_complete(put_c)
+            await put_c
 
         async def go():
             a = await q.get()
@@ -430,14 +444,16 @@ class QueuePutTests(_QueueTestBase):
             self.assertEqual(b, 'b')
             self.assertTrue(put_b.done())
 
-        self.loop.run_until_complete(go())
+        await go()
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_put_with_waiting_getters(self):
-        fut = self.loop.create_future()
+    @pytest.mark.asyncio
+    async def test_put_with_waiting_getters(self):
+        loop = janus.current_loop()
+        fut = loop.create_future()
 
         async def go():
             fut.set_result(None)
@@ -447,21 +463,22 @@ class QueuePutTests(_QueueTestBase):
         async def put():
             await q.put('a')
 
-        _q = janus.Queue(loop=self.loop)
+        _q = janus.Queue()
         q = _q.async_q
-        t = self.loop.create_task(go())
-        self.loop.run_until_complete(fut)
-        self.loop.run_until_complete(put())
-        self.assertEqual(self.loop.run_until_complete(t), 'a')
+        t = loop.create_task(go())
+        await fut
+        await put()
+        self.assertEqual(await t, 'a')
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
 
-class LifoQueueTests(_QueueTestBase):
-    def test_order(self):
-        _q = janus.LifoQueue(loop=self.loop)
+class LifoQueueTests(unittest.TestCase):
+    @pytest.mark.asyncio
+    async def test_order(self):
+        _q = janus.LifoQueue()
         q = _q.async_q
         for i in [1, 3, 2]:
             q.put_nowait(i)
@@ -471,12 +488,13 @@ class LifoQueueTests(_QueueTestBase):
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
 
-class PriorityQueueTests(_QueueTestBase):
-    def test_order(self):
-        _q = janus.PriorityQueue(loop=self.loop)
+class PriorityQueueTests(unittest.TestCase):
+    @pytest.mark.asyncio
+    async def test_order(self):
+        _q = janus.PriorityQueue()
         q = _q.async_q
         for i in [1, 3, 2]:
             q.put_nowait(i)
@@ -486,24 +504,27 @@ class PriorityQueueTests(_QueueTestBase):
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
 
 class _QueueJoinTestMixin:
 
     q_class = None
 
-    def test_task_done_underflow(self):
-        _q = self.q_class(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_task_done_underflow(self):
+        _q = self.q_class()
         q = _q.async_q
         self.assertRaises(ValueError, q.task_done)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_task_done(self):
-        _q = self.q_class(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_task_done(self):
+        loop = janus.current_loop()
+        _q = self.q_class()
         q = _q.async_q
         for i in range(100):
             q.put_nowait(i)
@@ -523,27 +544,28 @@ class _QueueJoinTestMixin:
                 q.task_done()
 
         async def test():
-            tasks = [self.loop.create_task(worker())
+            tasks = [loop.create_task(worker())
                      for index in range(2)]
 
             await q.join()
             return tasks
 
-        tasks = self.loop.run_until_complete(test())
+        tasks = await test()
         self.assertEqual(sum(range(100)), accumulator)
 
         # close running generators
         running = False
         for i in range(len(tasks)):
             q.put_nowait(0)
-        self.loop.run_until_complete(asyncio.wait(tasks, loop=self.loop))
+        await asyncio.wait(tasks)
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
-    def test_join_empty_queue(self):
-        _q = self.q_class(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_join_empty_queue(self):
+        _q = self.q_class()
         q = _q.async_q
 
         # Test that a queue join()s successfully, and before anything else
@@ -553,15 +575,16 @@ class _QueueJoinTestMixin:
             await q.join()
             await q.join()
 
-        self.loop.run_until_complete(join())
+        await join()
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
     @unittest.expectedFailure
-    def test_format(self):
-        _q = self.q_class(loop=self.loop)
+    @pytest.mark.asyncio
+    async def test_format(self):
+        _q = self.q_class()
         q = _q.async_q
         self.assertEqual(q._format(), 'maxsize=0')
 
@@ -570,16 +593,16 @@ class _QueueJoinTestMixin:
 
         self.assertFalse(_q._sync_mutex.locked())
         _q.close()
-        self.loop.run_until_complete(_q.wait_closed())
+        await _q.wait_closed()
 
 
-class QueueJoinTests(_QueueJoinTestMixin, _QueueTestBase):
+class QueueJoinTests(_QueueJoinTestMixin, unittest.TestCase):
     q_class = janus.Queue
 
 
-class LifoQueueJoinTests(_QueueJoinTestMixin, _QueueTestBase):
+class LifoQueueJoinTests(_QueueJoinTestMixin, unittest.TestCase):
     q_class = janus.LifoQueue
 
 
-class PriorityQueueJoinTests(_QueueJoinTestMixin, _QueueTestBase):
+class PriorityQueueJoinTests(_QueueJoinTestMixin, unittest.TestCase):
     q_class = janus.PriorityQueue

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import unittest
 
 import janus
@@ -7,6 +8,10 @@ import pytest
 
 class TestMixedMode(unittest.TestCase):
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason="forbidding implicit loop creation works on Python 3.7 or higher only",
+    )
     def test_ctor_noloop(self):
         with self.assertRaises(RuntimeError):
             janus.Queue()

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -10,7 +10,8 @@ class TestMixedMode(unittest.TestCase):
 
     @pytest.mark.skipif(
         sys.version_info < (3, 7),
-        reason="forbidding implicit loop creation works on Python 3.7 or higher only",
+        reason="forbidding implicit loop creation works on "
+               "Python 3.7 or higher only",
     )
     def test_ctor_noloop(self):
         with self.assertRaises(RuntimeError):

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = check, {py35,py36,py37,py38}-{debug,release}, report
 deps =
     coverage
     pytest
+    pytest-asyncio
 
 commands =
     coverage run -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = check, {py34,py35}-{debug,release}, report
+envlist = check, {py35,py36,py37,py38}-{debug,release}, report
 
 
 [testenv]
@@ -17,9 +17,10 @@ setenv =
     debug: PYTHONASYNCIODEBUG = 1
 
 basepython:
-    py33: python3.3
-    py34: python3.4
     py35: python3.5
+    py36: python3.6
+    py37: python3.7
+    py38: python3.8
 
 whitelist_externals =
     coverage


### PR DESCRIPTION
## What do these changes do?

* Remove all `loop=self.loop` expressions.
* Rely on the currently running loop in the constructor of Queue.
* Assuming that `janus.Queue` objects are created in the functions or coroutines called by the event loop, rewrite most test cases to be async.
  - No longer manage the event loop lifecycles by ourselves.
  - Adopt pytest-asyncio to seamlessly run test cases in an event loop.
* Add missing `.close()` / `.wait_closed()` calls to the end of many test cases to ensure proper termination of the queues.
* Insert `asyncio.sleep(0)` in the `wait_closed()` method so that all task-done callbacks for tasks spawned by `_notify_async_not_empty()`, `_notify_async_not_full()` internal methods are properly awaited.
  This eliminates hundreds of resource warnings after finishing the test suite and loop termination after using `.join()` APIs.
* Ensure dropping of Python 3.3/3.4 in CI configs.
* Add Python 3.7 and 3.8 to CI configs.

## Are there changes in behavior for the user?

Users are no longer able to create `janus.Queue` instances in the codes running *outside* event loops (even when they have references to an existing event loop running somewhere else).

## Related issue number

#229

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * There is no `CHANGES` folder, so I've added a bullet in `CHANGES.rst` directly.
