### PR TITLE
Fix join calls not raise RuntimeError after queue closing.

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -174,7 +174,7 @@ class Queue(Generic[T]):
 
     def _check_closing(self) -> None:
         if self._closing:
-            raise RuntimeError("Operation of closed queue is forbidden")
+            raise RuntimeError("Operation on the closed queue is forbidden")
 
 
 class _SyncQueueProxy(Generic[T]):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `join()` method calls not raise `RuntimeError` after queue closing.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

The `join()` method calls will raise `RuntimeError` after queue closing.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#294 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
