### PR TITLE
accept loop parameter for Queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changes
 =======
 
+- `Queue` now accepts `loop` argument. #297
+
 0.6.1 (2020-10-26)
 ------------------
 

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -22,8 +22,8 @@ if current_loop is None:
 
 
 class Queue(Generic[T]):
-    def __init__(self, maxsize: int = 0) -> None:
-        self._loop = current_loop()
+    def __init__(self, maxsize: int = 0, loop: Any = None) -> None:
+        self._loop = loop or current_loop()
         self._maxsize = maxsize
 
         self._init(maxsize)


### PR DESCRIPTION
## What do these changes do?

Use case: If one wants to create the Queue in the main thread of the app, but use
it with an async loop that is running in a thread (not the one in the main thread).

Otw. one would have to create the queue in the thread to pick up the correct loop.

## Are there changes in behavior for the user?

no change in behavior if used as before. Now user can pass a custom loop.

## Checklist

- [x] I think the code is well written
- [x] Add a new news fragment into the `CHANGES` folder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aio-libs/janus/297)
<!-- Reviewable:end -->
