### PR TITLE
Clarify supported python versions in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Usage example (Python 3.7+)
 
 Usage example (Python 3.5 and 3.6)
 ==================================
+**N.B. For python 3.6 and below you must use janus <= 1.0.0**
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Usage example (Python 3.7+)
 
 Usage example (Python 3.5 and 3.6)
 ==================================
-**N.B. For python 3.6 and below you must use janus <= 1.0.0**
+**N.B. For python 3.6 and below you must use janus < 1.0.0**
 
 .. code:: python
 


### PR DESCRIPTION
Small tweak to help users figure out that janus no longer supports python < 3.7