### PR TITLE
Use typing_extensions only on Python 3.7 and lower

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -9,7 +9,11 @@ from queue import Empty as SyncQueueEmpty
 from queue import Full as SyncQueueFull
 from typing import Any, Callable, Deque, Generic, List, Optional, Set, TypeVar
 
-from typing_extensions import Protocol
+try:
+    # Python 3.8+
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
 
 __version__ = "1.0.0"
 __all__ = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ zip_safe = True
 include_package_data = True
 
 install_requires =
-    typing-extensions>=3.7.4.3
+    typing-extensions>=3.7.4.3;python_version<"3.8"
 
 [flake8]
 exclude = .git,.env,__pycache__,.eggs


### PR DESCRIPTION
Protocol was added with PEP 544 to Python 3.8+

## What do these changes do?

They remove a dependency on the package `typing_extensions` when it's not needed

## Are there changes in behavior for the user?

No, it's a change directed at package maintainers for Linux distributions

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
