### PR TITLE
Make not-full and not-empty notificatios faster

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -176,7 +176,7 @@ class Queue(Generic[T]):
         self._unfinished_tasks += 1
         self._finished.clear()
 
-    def _sync_not_empty_notifier(self):
+    def _sync_not_empty_notifier(self) -> None:
         with self._sync_mutex:
             self._sync_not_empty.notify()
 


### PR DESCRIPTION
The speed-up removes creation of 4 internal functions per each `get` or `put`, both sync and async calls are affected.