### PR TITLE
Reduce notifications for a minor speedup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changes
 
 - Add ``.aclose()`` async method #709
 
+- Reduce notifications for a minor speedup #704
+
 1.1.0 (2024-10-30)
 ------------------
 

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -323,36 +323,91 @@ class TestMixedMode:
         await q.wait_closed()
 
     @pytest.mark.asyncio
-    async def test_sync_get_notifies_async_not_full(self):
+    async def test_put_notifies_sync_not_empty(self):
         loop = asyncio.get_running_loop()
-        q = janus.Queue(1)
-        ev1 = asyncio.Event()
-        ev2 = asyncio.Event()
+        q = janus.Queue()
 
-        vals = []
+        futures = [
+            loop.run_in_executor(None, q.sync_q.get)
+            for _ in range(4)
+        ]
 
-        async def fill_queue():
-            await q.async_q.put(1)
-            ev1.set()
-            await q.async_q.put(2)  # blocked here
-            await ev2.wait()
-            val = await q.async_q.get()
-            vals.append(val)
+        while q._sync_not_empty_waiting != 4:
+            await asyncio.sleep(0.001)
 
-        task = asyncio.create_task(fill_queue())
-        await ev1.wait()
+        q.sync_q.put_nowait(1)
+        q.async_q.put_nowait(2)
+        await loop.run_in_executor(None, q.sync_q.put, 3)
+        await q.async_q.put(4)
 
-        def sync_get():
-            val = q.sync_q.get()
-            vals.append(val)
-            val = q.sync_q.get()
-            vals.append(val)
-            q.sync_q.put(3)
-            loop.call_soon_threadsafe(ev2.set)
+        await asyncio.gather(*futures)
+        assert q.sync_q.empty()
+        await q.aclose()
 
-        await loop.run_in_executor(None, sync_get)
-        await task
-        assert vals == [1, 2, 3]
+    @pytest.mark.asyncio
+    async def test_put_notifies_async_not_empty(self):
+        loop = asyncio.get_running_loop()
+        q = janus.Queue()
 
-        assert q.sync_q.empty
+        tasks = [
+            loop.create_task(q.async_q.get())
+            for _ in range(4)
+        ]
+
+        await asyncio.sleep(0)
+
+        q.sync_q.put_nowait(1)
+        q.async_q.put_nowait(2)
+        await loop.run_in_executor(None, q.sync_q.put, 3)
+        await q.async_q.put(4)
+
+        await asyncio.gather(*tasks)
+        assert q.sync_q.empty()
+        await q.aclose()
+
+    @pytest.mark.asyncio
+    async def test_get_notifies_sync_not_full(self):
+        loop = asyncio.get_running_loop()
+        q = janus.Queue(2)
+        q.sync_q.put_nowait(1)
+        q.sync_q.put_nowait(2)
+
+        futures = [
+            loop.run_in_executor(None, q.sync_q.put, object())
+            for _ in range(4)
+        ]
+
+        while q._sync_not_full_waiting != 4:
+            await asyncio.sleep(0.001)
+
+        q.sync_q.get_nowait()
+        q.async_q.get_nowait()
+        await loop.run_in_executor(None, q.sync_q.get)
+        await q.async_q.get()
+
+        await asyncio.gather(*futures)
+        assert q.sync_q.qsize() == 2
+        await q.aclose()
+
+    @pytest.mark.asyncio
+    async def test_get_notifies_async_not_full(self):
+        loop = asyncio.get_running_loop()
+        q = janus.Queue(2)
+        q.sync_q.put_nowait(1)
+        q.sync_q.put_nowait(2)
+
+        tasks = [
+            loop.create_task(q.async_q.put(object()))
+            for _ in range(4)
+        ]
+
+        await asyncio.sleep(0)
+
+        q.sync_q.get_nowait()
+        q.async_q.get_nowait()
+        await loop.run_in_executor(None, q.sync_q.get)
+        await q.async_q.get()
+
+        await asyncio.gather(*tasks)
+        assert q.sync_q.qsize() == 2
         await q.aclose()

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -322,23 +322,26 @@ class TestMixedMode:
 
         await q.wait_closed()
 
+
     @pytest.mark.asyncio
     async def test_sync_get_notifies_async_not_full(self):
         loop = asyncio.get_running_loop()
         q = janus.Queue(1)
-        ev = asyncio.Event()
+        ev1 = asyncio.Event()
+        ev2 = asyncio.Event()
 
         vals = []
 
         async def fill_queue():
             await q.async_q.put(1)
-            ev.set()
+            ev1.set()
             await q.async_q.put(2)  # blocked here
+            await ev2.wait()
             val = await q.async_q.get()
             vals.append(val)
 
         task = asyncio.create_task(fill_queue())
-        await ev.wait()
+        await ev1.wait()
 
         def sync_get():
             val = q.sync_q.get()
@@ -346,9 +349,11 @@ class TestMixedMode:
             val = q.sync_q.get()
             vals.append(val)
             q.sync_q.put(3)
+            loop.call_soon_threadsafe(ev2.set)
 
         await loop.run_in_executor(None, sync_get)
         await task
         assert vals == [1, 2, 3]
 
+        assert q.sync_q.empty
         await q.aclose()

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -322,7 +322,6 @@ class TestMixedMode:
 
         await q.wait_closed()
 
-
     @pytest.mark.asyncio
     async def test_sync_get_notifies_async_not_full(self):
         loop = asyncio.get_running_loop()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -416,7 +416,14 @@ class TestFailingQueue(BlockingTestMixin):
         # we are pacthing loop to follow setUp/tearDown agreement
         with patch.object(loop, "call_soon_threadsafe") as func:
             func.side_effect = RuntimeError()
-            q.put_nowait(1)
+            task = loop.create_task(_q.async_q.get())
+            await asyncio.sleep(0)
+            try:
+                q.put_nowait(1)
+            finally:
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
             assert func.call_count == 1
         _q.close()
         await _q.wait_closed()


### PR DESCRIPTION
Avoids calling slow notification methods when there are no waiters.