### PR TITLE
Simplify pending tasks logic

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -207,7 +207,7 @@ class Queue(Generic[T]):
         if threadsafe:
             self._call_soon_threadsafe(self._make_async_not_empty_notifier)
         else:
-            self._call_soon(self._make_async_not_empty_notifier)
+            self._make_async_not_empty_notifier()
 
     async def _async_not_full_notifier(self) -> None:
         async with self._async_mutex:
@@ -222,7 +222,7 @@ class Queue(Generic[T]):
         if threadsafe:
             self._call_soon_threadsafe(self._make_async_not_full_notifier)
         else:
-            self._call_soon(self._make_async_not_full_notifier)
+            self._make_async_not_full_notifier()
 
     def _check_closing(self) -> None:
         if self._closing:

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -237,6 +237,7 @@ class TestMixedMode:
         assert not q.async_q.closed
         assert not q.sync_q.closed
         q.close()
+        await q.wait_closed()
         assert q.closed
         assert q.async_q.closed
         assert q.sync_q.closed


### PR DESCRIPTION
async notifiers called from asyncio doesn't require `.call_soon()`.