### PR TITLE
Add .aclose() async method

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -137,6 +137,10 @@ class Queue(Generic[T]):
             return
         await asyncio.wait(self._pending)
 
+    async def aclose(self) -> None:
+        self.close()
+        await self.wait_closed()
+
     @property
     def closed(self) -> bool:
         return self._closing and not self._pending

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -17,8 +17,10 @@ async def close(_q):
     else:
         assert not _q._sync_mutex.locked()
 
-    _q.close()
-    await _q.wait_closed()
+    await _q.aclose()
+    assert _q.closed
+    assert _q.sync_q.closed
+    assert _q.async_q.closed
 
 
 class TestQueueBasic:


### PR DESCRIPTION
Is is a simple shortcut for `q.close()` + `await q.wait_closed()` calls