### PR TITLE
Fix notifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Changes
 
 - Remove sync notifiers for a major speedup #714
 
+- Fix hang in AsyncQueue.join() #716
+
 1.1.0 (2024-10-30)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes
 
 - Optimize internal implementation for a little speedup #699
 
-- Make not-full and not-empty notificatios faster #703
+- Make not-full and not-empty notifications faster #703
 
 - Add ``.aclose()`` async method #709
 
@@ -16,7 +16,7 @@ Changes
 
 - Remove sync notifiers for a major speedup #714
 
-- Fix hang in AsyncQueue.join() #716
+- Fix hang in ``AsyncQueue.join()`` #716
 
 1.1.0 (2024-10-30)
 ------------------

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -144,10 +144,10 @@ class Queue(Generic[T]):
             for fut in self._pending:
                 fut.cancel()
             if self._async_tasks_done_waiting:
-                assert self._loop is not None
-                self._call_soon_threadsafe(  # unblocks all async_q.join()
-                    self._make_async_tasks_done_notifier, self._loop
-                )
+                if self._loop is not None:
+                    self._call_soon_threadsafe(  # unblocks all async_q.join()
+                        self._make_async_tasks_done_notifier, self._loop
+                    )
             if self._sync_tasks_done_waiting:
                 self._sync_tasks_done.notify_all()  # unblocks all sync_q.join()
 
@@ -281,10 +281,10 @@ class _SyncQueueProxy(SyncQueue[T]):
                 if parent._sync_tasks_done_waiting:
                     parent._sync_tasks_done.notify_all()
                 if parent._async_tasks_done_waiting:
-                    assert parent._loop is not None
-                    parent._call_soon_threadsafe(
-                        parent._make_async_tasks_done_notifier, parent._loop
-                    )
+                    if parent._loop is not None:
+                        parent._call_soon_threadsafe(
+                            parent._make_async_tasks_done_notifier, parent._loop
+                        )
             parent._unfinished_tasks = unfinished
 
     def join(self) -> None:
@@ -382,10 +382,10 @@ class _SyncQueueProxy(SyncQueue[T]):
             if parent._sync_not_empty_waiting:
                 parent._sync_not_empty.notify()
             if parent._async_not_empty_waiting:
-                assert parent._loop is not None
-                parent._call_soon_threadsafe(
-                    parent._make_async_not_empty_notifier, parent._loop
-                )
+                if parent._loop is not None:
+                    parent._call_soon_threadsafe(
+                        parent._make_async_not_empty_notifier, parent._loop
+                    )
 
     def get(self, block: bool = True, timeout: OptFloat = None) -> T:
         """Remove and return an item from the queue.
@@ -428,10 +428,10 @@ class _SyncQueueProxy(SyncQueue[T]):
             if parent._sync_not_full_waiting:
                 parent._sync_not_full.notify()
             if parent._async_not_full_waiting:
-                assert parent._loop is not None
-                parent._call_soon_threadsafe(
-                    parent._make_async_not_full_notifier, parent._loop
-                )
+                if parent._loop is not None:
+                    parent._call_soon_threadsafe(
+                        parent._make_async_not_full_notifier, parent._loop
+                    )
             return item
 
     def put_nowait(self, item: T) -> None:
@@ -637,10 +637,10 @@ class _AsyncQueueProxy(AsyncQueue[T]):
             parent._unfinished_tasks -= 1
             if parent._unfinished_tasks == 0:
                 if parent._async_tasks_done_waiting:
-                    assert parent._loop is not None
-                    parent._call_soon_threadsafe(
-                        parent._make_async_tasks_done_notifier, parent._loop
-                    )
+                    if parent._loop is not None:
+                        parent._call_soon_threadsafe(
+                            parent._make_async_tasks_done_notifier, parent._loop
+                        )
                 if parent._sync_tasks_done_waiting:
                     parent._sync_tasks_done.notify_all()
 

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -144,6 +144,7 @@ class Queue(Generic[T]):
             for fut in self._pending:
                 fut.cancel()
             if self._async_tasks_done_waiting:
+                assert self._loop is not None
                 self._call_soon_threadsafe(  # unblocks all async_q.join()
                     self._make_async_tasks_done_notifier, self._loop
                 )
@@ -280,6 +281,7 @@ class _SyncQueueProxy(SyncQueue[T]):
                 if parent._sync_tasks_done_waiting:
                     parent._sync_tasks_done.notify_all()
                 if parent._async_tasks_done_waiting:
+                    assert parent._loop is not None
                     parent._call_soon_threadsafe(
                         parent._make_async_tasks_done_notifier, parent._loop
                     )
@@ -380,10 +382,10 @@ class _SyncQueueProxy(SyncQueue[T]):
             if parent._sync_not_empty_waiting:
                 parent._sync_not_empty.notify()
             if parent._async_not_empty_waiting:
-                if parent._loop is not None:
-                    parent._call_soon_threadsafe(
-                        parent._make_async_not_empty_notifier, parent._loop
-                    )
+                assert parent._loop is not None
+                parent._call_soon_threadsafe(
+                    parent._make_async_not_empty_notifier, parent._loop
+                )
 
     def get(self, block: bool = True, timeout: OptFloat = None) -> T:
         """Remove and return an item from the queue.
@@ -426,10 +428,10 @@ class _SyncQueueProxy(SyncQueue[T]):
             if parent._sync_not_full_waiting:
                 parent._sync_not_full.notify()
             if parent._async_not_full_waiting:
-                if parent._loop is not None:
-                    parent._call_soon_threadsafe(
-                        parent._make_async_not_full_notifier, parent._loop
-                    )
+                assert parent._loop is not None
+                parent._call_soon_threadsafe(
+                    parent._make_async_not_full_notifier, parent._loop
+                )
             return item
 
     def put_nowait(self, item: T) -> None:
@@ -635,6 +637,7 @@ class _AsyncQueueProxy(AsyncQueue[T]):
             parent._unfinished_tasks -= 1
             if parent._unfinished_tasks == 0:
                 if parent._async_tasks_done_waiting:
+                    assert parent._loop is not None
                     parent._call_soon_threadsafe(
                         parent._make_async_tasks_done_notifier, parent._loop
                     )

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -144,10 +144,9 @@ class Queue(Generic[T]):
             for fut in self._pending:
                 fut.cancel()
             if self._async_tasks_done_waiting:
-                if self._loop is not None:
-                    self._call_soon_threadsafe(  # unblocks all async_q.join()
-                        self._make_async_tasks_done_notifier, self._loop
-                    )
+                self._call_soon_threadsafe(  # unblocks all async_q.join()
+                    self._make_async_tasks_done_notifier, self._loop
+                )
             if self._sync_tasks_done_waiting:
                 self._sync_tasks_done.notify_all()  # unblocks all sync_q.join()
 
@@ -281,10 +280,9 @@ class _SyncQueueProxy(SyncQueue[T]):
                 if parent._sync_tasks_done_waiting:
                     parent._sync_tasks_done.notify_all()
                 if parent._async_tasks_done_waiting:
-                    if parent._loop is not None:
-                        parent._call_soon_threadsafe(
-                            parent._make_async_tasks_done_notifier, parent._loop
-                        )
+                    parent._call_soon_threadsafe(
+                        parent._make_async_tasks_done_notifier, parent._loop
+                    )
             parent._unfinished_tasks = unfinished
 
     def join(self) -> None:
@@ -637,10 +635,9 @@ class _AsyncQueueProxy(AsyncQueue[T]):
             parent._unfinished_tasks -= 1
             if parent._unfinished_tasks == 0:
                 if parent._async_tasks_done_waiting:
-                    if parent._loop is not None:
-                        parent._call_soon_threadsafe(
-                            parent._make_async_tasks_done_notifier, parent._loop
-                        )
+                    parent._call_soon_threadsafe(
+                        parent._make_async_tasks_done_notifier, parent._loop
+                    )
                 if parent._sync_tasks_done_waiting:
                     parent._sync_tasks_done.notify_all()
 
@@ -656,23 +653,19 @@ class _AsyncQueueProxy(AsyncQueue[T]):
         parent._check_closing()
         async with parent._async_tasks_done:
             parent._sync_mutex.acquire()
-            locked = True
             parent._get_loop()  # check the event loop
             try:
                 while parent._unfinished_tasks:
                     parent._async_tasks_done_waiting += 1
-                    locked = False
                     parent._sync_mutex.release()
                     try:
                         await parent._async_tasks_done.wait()
                     finally:
                         parent._sync_mutex.acquire()
-                        locked = True
                         parent._async_tasks_done_waiting -= 1
                     parent._check_closing()
             finally:
-                if locked:
-                    parent._sync_mutex.release()
+                parent._sync_mutex.release()
 
 
 class PriorityQueue(Queue[T]):


### PR DESCRIPTION
## What do these changes do?

This PR fixes hang in `AsyncQueue.join()` by replacing `asyncio.Event` with `asyncio.Condition`. It also:

1. Makes the names of primitives the same style.
2. Reduces notifications in #704 style.
3. Ensures that counters are changed exclusively.

## Are there changes in behavior for the user?

There are no behavior changes for users.

## Related issue number

Fixes #715