### PR TITLE
Fix event loop binding

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -573,7 +573,6 @@ class _AsyncQueueProxy(AsyncQueue[T]):
             if parent._is_shutdown:
                 raise AsyncQueueShutDown
 
-            parent._get_loop()
             if 0 < parent._maxsize <= parent._qsize():
                 raise AsyncQueueFull
 
@@ -626,7 +625,6 @@ class _AsyncQueueProxy(AsyncQueue[T]):
             if not parent._qsize():
                 raise AsyncQueueEmpty
 
-            parent._get_loop()
             item = parent._get()
             if parent._async_not_full_waiting:
                 parent._notify_async(parent._async_not_full.notify)


### PR DESCRIPTION
## What do these changes do?

In a multithreaded environment, it is possible that nowait methods may be called in event loops other than the one in which asynchronous methods are called. As a result, simultaneous binding to two different event loops is possible, because of which some methods will not work. This PR fixes this bug and ensures that RuntimeError is safely raised.

Side effect: nowait methods no longer depend on the event loop (and do not raise a RuntimeError when used from a different event loop).

## Are there changes in behavior for the user?

There are no behavior changes for users.