### PR TITLE
Add appropriate bound on typevar for PriorityQueue

### DIFF
--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -8,7 +8,7 @@ from heapq import heappop, heappush
 from queue import Empty as SyncQueueEmpty
 from queue import Full as SyncQueueFull
 from time import monotonic
-from typing import Callable, Generic, Optional, Protocol, TypeVar
+from typing import Any, Callable, Generic, Optional, Protocol, TypeAlias, TypeVar
 
 if sys.version_info >= (3, 13):
     from asyncio import QueueShutDown as AsyncQueueShutDown
@@ -41,6 +41,19 @@ __all__ = (
     "BaseQueue",
 )
 
+_contra_T = TypeVar("_contra_T", contravariant=True)
+
+class SupportsLT(Protocol[_contra_T]):
+    def __lt__(self, other: _contra_T):  ...
+
+
+class SupportsGT(Protocol[_contra_T]):
+    def __gt__(self, other: _contra_T):  ...
+
+
+RichComparable: TypeAlias = SupportsGT[Any] | SupportsLT[Any]
+
+RichComparableT = TypeVar("RichComparableT", bound=RichComparable)
 
 T = TypeVar("T")
 OptFloat = Optional[float]
@@ -696,7 +709,7 @@ class _AsyncQueueProxy(AsyncQueue[T]):
         self._parent.shutdown(immediate)
 
 
-class PriorityQueue(Queue[T]):
+class PriorityQueue(Queue[RichComparableT]):
     """Variant of Queue that retrieves open entries in priority order
     (lowest first).
 
@@ -705,15 +718,15 @@ class PriorityQueue(Queue[T]):
     """
 
     def _init(self, maxsize: int) -> None:
-        self._heap_queue: list[T] = []
+        self._heap_queue: list[RichComparableT] = []
 
     def _qsize(self) -> int:
         return len(self._heap_queue)
 
-    def _put(self, item: T) -> None:
+    def _put(self, item: RichComparableT) -> None:
         heappush(self._heap_queue, item)
 
-    def _get(self) -> T:
+    def _get(self) -> RichComparableT:
         return heappop(self._heap_queue)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a comparison bound matching the runtime requirement that heapq requires implementation of either `__lt__` or `__gt__`

This was noticed in the [primer output](https://github.com/python/typeshed/pull/14419#issuecomment-3076457558) during a corresponding change in the typeshed to more accurately type heapq

## Are there changes in behavior for the user?

No runtime behavioral changes. This may help detect things that would be errors at runtime during static analysis.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
